### PR TITLE
Add USER network for network isolation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,8 @@
   </pluginRepositories>
 
   <properties>
-    <mesos.version>0.27.3</mesos.version>
-    <protobuf.version>3.0.0</protobuf.version>
+    <mesos.version>1.2.0</mesos.version>
+    <protobuf.version>3.2.0</protobuf.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.2</powermock.version>
     <assertj.version>2.1.0</assertj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.609</version><!-- the minimum Jenkins core compatible version to run plugin on -->
+    <version>1.609</version>
   </parent>
 
   <artifactId>mesos</artifactId>
@@ -12,9 +12,9 @@
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Mesos+Plugin</url>
 
   <scm>
-    <connection>scm:git:https://github.com/goettl79/mesos-plugin.git</connection>
-    <developerConnection>scm:git:https://github.com/goettl79/mesos-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/mesos-plugin</url>
+    <connection>scm:git:https://github.com/infonova/mesos-plugin.git</connection>
+    <developerConnection>scm:git:https://github.com/infonova/mesos-plugin.git</developerConnection>
+    <url>https://github.com/infonova/mesos-plugin</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -190,7 +190,7 @@
           <extension>
               <groupId>org.apache.maven.wagon</groupId>
               <artifactId>wagon-webdav-jackrabbit</artifactId>
-              <version>1.0</version>
+              <version>2.10</version>
           </extension>
       </extensions>
   </build>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/config/MesosPluginConfiguration/configureSlaveDefinitionsView.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/config/MesosPluginConfiguration/configureSlaveDefinitionsView.jelly
@@ -184,6 +184,46 @@
                                     </f:repeatable>
                                   </f:entry>
                                 </f:radioBlock>
+                                <f:radioBlock id="networking.USER" name="networking" title="${%User}" value="USER" inline="true" checked="${slaveInfo.containerInfo.networking == 'USER'}" >
+                                  <f:entry title="${%Port Mappings}">
+                                    <f:repeatable
+                                            header="${%Port mapping}"
+                                            add="${%Add Port Mapping}"
+                                            var="portMapping"
+                                            name="portMappings"
+                                            items="${slaveInfo.containerInfo.portMappings}"
+                                            noAddButton="false"
+                                            minimum="0">
+                                      <fieldset>
+                                        <table width="100%">
+                                          <f:entry title="${%Container Port}" field="containerPort">
+                                            <f:textbox clazz="required positive-number" default="" value="${portMapping.containerPort}" />
+                                          </f:entry>
+                                          <f:entry title="${%Host Port}" field="hostPort">
+                                            <f:textbox clazz="positive-number" default="" value="${portMapping.hostPort}" />
+                                          </f:entry>
+                                          <f:entry title="${%Protocol}" field="protocol">
+                                            <select name="protocol" value="${portMapping.protocol}" class="setting-input select">
+                                              <f:option value="tcp" selected="${portMapping.protocol == 'tcp'}">tcp</f:option>
+                                              <f:option value="udp" selected="${portMapping.protocol == 'udp'}">udp</f:option>
+                                            </select>
+                                          </f:entry>
+                                          <f:entry title="${%Description}" field="portMapping.description">
+                                            <f:textbox clazz="required" default="" value="${portMapping.description}" />
+                                          </f:entry>
+                                          <f:entry title="${%URL Format}" field="portMapping.urlFormat">
+                                            <f:textbox default="http://{hostname}:{port}" value="${portMapping.urlFormat}" />
+                                          </f:entry>
+                                          <f:entry>
+                                            <div align="right" class="repeatable-delete show-if-only" style="margin-left: 1em;">
+                                              <f:repeatableDeleteButton value="${%Delete Port Mapping}" /><br/>
+                                            </div>
+                                          </f:entry>
+                                        </table>
+                                      </fieldset>
+                                    </f:repeatable>
+                                  </f:entry>
+                                </f:radioBlock>
                               </f:entry>
 
                               <f:entry title="${%Volumes}">


### PR DESCRIPTION
This adds the possibility to specify a USER network.
For security reasons, right now the network name is generated using the principal and
the name of the framework (spaces are converted to dashes).

Later maybe, this "security" mechanism should be replaced by appropriate authentication/authorization
on the Mesos cluster and free to choose names for networks (has to exist however)