### PR TITLE
Specify limits for resources (CPU and RAM) per framework

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -1034,18 +1034,24 @@ public class JenkinsScheduler implements Scheduler {
     }
   }
 
-  public boolean removeRequestMatchingLabel(String labelString) {
+  public Request getRequestForLinkedItem(String linkedItem) {
     try {
       for (Request request : requests) {
-        if (request.request.slaveInfo.getLabelString().equals(labelString)) {
-          requests.remove(request);
-          LOGGER.info("Removed request for Label " + request.request.slaveInfo.getLabelString());
-          return true;
+        if (StringUtils.equals(request.request.slave.getLinkedItem(),linkedItem)) {
+          return request;
         }
       }
     } catch (Exception e) {
-      LOGGER.info("Error while removing request: " + e.getMessage());
-      e.printStackTrace();
+      LOGGER.log(Level.WARNING, "Error while finding request: ", e);
+    }
+    return null;
+  }
+
+  public boolean removeRequestForLinkedItem(String linkedItem) {
+    Request request = getRequestForLinkedItem(linkedItem);
+    if(request != null) {
+      requests.remove(request);
+      return true;
     }
     return false;
   }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -58,6 +58,8 @@ public class MesosCloud extends Cloud {
   private String description;
   private String frameworkName;
   private String role;
+  private double maxCpus;
+  private int maxMem;
   private String slavesUser;
   private String principal;
   private String secret;
@@ -121,6 +123,8 @@ public class MesosCloud extends Cloud {
       String description,
       String frameworkName,
       String role,
+      double maxCpus,
+      int maxMem,
       String slavesUser,
       String principal,
       String secret,
@@ -136,6 +140,8 @@ public class MesosCloud extends Cloud {
     this.description = description;
     this.frameworkName = frameworkName;
     this.role = role;
+    this.maxCpus = maxCpus;
+    this.maxMem = maxMem;
     this.slavesUser = slavesUser;
     this.principal = principal;
     this.secret = secret;
@@ -316,7 +322,7 @@ public class MesosCloud extends Cloud {
     int memory = (int)((slaveInfo.getSlaveMem() + (numExecutors * slaveInfo.getExecutorMem())) * (1 + JVM_MEM_OVERHEAD_FACTOR));
 
 
-    Mesos.JenkinsSlave jenkinsSlave = new Mesos.JenkinsSlave(name,slaveInfo.getLabelString(), numExecutors, linkedItem);
+    Mesos.JenkinsSlave jenkinsSlave = new Mesos.JenkinsSlave(name,slaveInfo.getLabelString(), numExecutors, linkedItem, cpus, memory);
     Mesos.SlaveRequest slaveRequest = new Mesos.SlaveRequest(jenkinsSlave, cpus, memory, role, slaveInfo);
     Mesos mesos = Mesos.getInstance(this);
 
@@ -334,12 +340,11 @@ public class MesosCloud extends Cloud {
       }
 
       @Override
-      public void failed(Mesos.JenkinsSlave slave) {
+      public void failed(Mesos.JenkinsSlave slave, Mesos.SlaveResult.FAILED_CAUSE cause) {
         try {
-          MesosTaskFailureMonitor.getInstance().addFailedSlave(slave);
+          MesosTaskFailureMonitor.getInstance().addFailedSlave(slave, cause);
         } catch (Exception e) {
-          LOGGER.fine("Error while getting MesosTaskFailureMonitor " + e.getMessage());
-          e.printStackTrace();
+          LOGGER.log(Level.WARNING, "Error while getting MesosTaskFailureMonitor", e);
         }
       }
     });
@@ -449,6 +454,22 @@ public class MesosCloud extends Cloud {
 
   public void setRole(String role) {
     this.role = role;
+  }
+
+  public double getMaxCpus() {
+    return maxCpus;
+  }
+
+  public void setMaxCpus(double maxCpus) {
+    this.maxCpus = maxCpus;
+  }
+
+  public int getMaxMem() {
+    return maxMem;
+  }
+
+  public void setMaxMem(int maxMem) {
+    this.maxMem = maxMem;
   }
 
   public String getSlavesUser() {
@@ -568,6 +589,8 @@ public class MesosCloud extends Cloud {
     private String description;
     private String frameworkName;
     private String role;
+    private double maxCpus;
+    private int maxMem;
     private String slavesUser;
     private String principal;
     private String secret;
@@ -592,6 +615,8 @@ public class MesosCloud extends Cloud {
       description = object.getString("description");
       frameworkName = object.getString("frameworkName");
       role = object.getString("role");
+      maxCpus = object.getDouble("maxCpus");
+      maxMem = object.getInt("maxMem");
       principal = object.getString("principal");
       secret = object.getString("secret");
       slaveAttributes = object.getString("slaveAttributes");

--- a/src/main/java/org/jenkinsci/plugins/mesos/listener/MesosQueueListener.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/listener/MesosQueueListener.java
@@ -12,10 +12,9 @@ import org.apache.mesos.Scheduler;
 import org.jenkinsci.plugins.mesos.JenkinsScheduler;
 import org.jenkinsci.plugins.mesos.Mesos;
 import org.jenkinsci.plugins.mesos.MesosCloud;
-import org.jenkinsci.plugins.mesos.config.acl.MesosFrameworkToItemMapper;
 import org.jenkinsci.plugins.mesos.config.slavedefinitions.MesosSlaveInfo;
-import org.jenkinsci.plugins.mesos.*;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @SuppressWarnings("rawtypes")
@@ -66,7 +65,7 @@ public class MesosQueueListener extends QueueListener {
               if (scheduler != null) {
                 if (scheduler instanceof JenkinsScheduler) {
                   JenkinsScheduler jenkinsScheduler = (JenkinsScheduler) scheduler;
-                  if (jenkinsScheduler.removeRequestMatchingLabel(li.getAssignedLabel().getDisplayName())) {
+                  if (jenkinsScheduler.removeRequestForLinkedItem(mesosCloud.getFullNameOfTask(li.task))) {
                     return; //it should only remove one task
                   }
                 }
@@ -76,8 +75,7 @@ public class MesosQueueListener extends QueueListener {
         }
       }
     } catch (Exception e) {
-      LOGGER.fine("Error while removing request from buildable Item " + e.getMessage());
-      e.printStackTrace();
+      LOGGER.log(Level.WARNING, "Error while removing request from buildable Item", e);
     }
   }
 

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -19,6 +19,14 @@
         <f:textbox field="role" default="*" clazz="required"/>
     </f:entry>
 
+    <f:entry title="${%Maximum CPU allocation}" field="maxCpus">
+        <f:textbox field="maxCpus" default="-1" clazz="required"/>
+    </f:entry>
+
+    <f:entry title="${%Maximum memory allocation}" field="maxMem">
+        <f:textbox field="maxMem" default="-1" clazz="required"/>
+    </f:entry>
+
     <f:entry title="${%Slave username}">
         <f:textbox field="slavesUser" default=""/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-maxCpus.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-maxCpus.html
@@ -1,0 +1,3 @@
+<div>
+    The maximum number of CPUs this framework can allocate.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-maxMem.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-maxMem.html
@@ -1,0 +1,3 @@
+<div>
+    The maximum number of memory (RAM) in MB this framework can allocate.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/monitoring/MesosTaskFailureMonitor/message.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/monitoring/MesosTaskFailureMonitor/message.groovy
@@ -7,9 +7,8 @@ if (my.isFixingActive()) {
         raw _("inProgress",my.url)
     }
 } else if (my.logFile.exists()) {
-    form(method:"POST",action:"${my.url}/dismiss",name:"dismissFailedTasks") {
+    div(class:"info") {
         raw _("completed",my.url)
-        f.submit(name:"dismiss",value:_("Dismiss this message"))
     }
 }
 
@@ -21,13 +20,14 @@ if (!my.failedSlaves.isEmpty()) {
         ul {
             my.failedSlaves.each { failedSlave ->
                 li {
-                    a(href:rootURL + '/computer/' + failedSlave, failedSlave)
+                    a(href:rootURL + '/computer/' + failedSlave.key, "${failedSlave.key} (${failedSlave.value})")
                 }
             }
         }
 
         div(align:"right") {
-            f.submit(name:"fix",value:_("retry failed tasks"))
+            f.submit(name:"fix",value:_("Retry failed tasks"))
+            f.submit(name:"dismiss",value:_("Ignore failed tasks (no reprovisioning)"))
         }
     }
 }


### PR DESCRIPTION
This  introduces configurable limits for CPU and RAM.
Thus, administrators are now able to specify maximum values for
those resources on a per framework basis.

Additional Bugfix:
Make sure only requests linked to item are deleted