### PR TITLE
Do not allow removal of used slave definitions

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/config/slavedefinitions/SlaveDefinitionsConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/config/slavedefinitions/SlaveDefinitionsConfiguration.java
@@ -22,12 +22,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.logging.Logger;
 
 @ExportedBean
 public class SlaveDefinitionsConfiguration implements Describable<SlaveDefinitionsConfiguration> {
-
-  private static final Logger LOGGER = Logger.getLogger(SlaveDefinitionsConfiguration.class.getName());
 
   @Extension
   public static class DescriptorImpl extends Descriptor<SlaveDefinitionsConfiguration> {
@@ -57,7 +54,7 @@ public class SlaveDefinitionsConfiguration implements Describable<SlaveDefinitio
       return null;
     }
 
-    public boolean slaveDefinitionsEntryExists(String slaveDefinitionsName) {
+    private boolean slaveDefinitionsEntryExists(String slaveDefinitionsName) {
       return getSlaveInfos(slaveDefinitionsName) != null;
     }
 
@@ -246,11 +243,12 @@ public class SlaveDefinitionsConfiguration implements Describable<SlaveDefinitio
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public Descriptor<SlaveDefinitionsConfiguration> getDescriptor() {
     return Jenkins.getInstance().getDescriptorOrDie(getClass());
   }
 
-  public DescriptorImpl getDescriptorImpl() {
+  private DescriptorImpl getDescriptorImpl() {
     return (DescriptorImpl) getDescriptor();
   }
 

--- a/src/main/resources/org/jenkinsci/plugins/mesos/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/Messages.properties
@@ -35,6 +35,7 @@ MesosApi.SuccessfullyUpdatedSlaveDefinitions=Successfully updated Slave definiti
 MesosApi.CreateSlaveDefinitionsEntryBadRequest=Please provide valid data (XML) to create a new Slave definitions entry
 MesosApi.SuccessfullyRemovedSlaveDefinitionsEntry=Successfully removed Slave definitions entry "{0}"
 MesosApi.NotRemovedSlaveDefinitionsEntry=Slave definitions entry with name "{0}" could not be found
+MesosApi.NotRemovedInUseSlaveDefinitionsEntry=Slave definitions entry "{0}" is used by "{1}"
 
 #AddACLEntryCommand
 AddACLEntryCommand.ShortDescription=Adds an ACL entry to the Mesos Framework to Jenkins Item pattern ACL entries.


### PR DESCRIPTION
This commit introduces a validation when trying to remove used slave definitions.
 As a side effect it is also not allowed to update the name of an existing and used slave definitions entry.