### PR TITLE
PLEASE CLOSE: Fix Slave Resource Usage link isn't reliably shown in build logfiles.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -1144,9 +1144,9 @@ public class JenkinsScheduler implements Scheduler {
   private String extractContainerIdFromTaskStatus(TaskStatus taskStatus) {
     try {
       if (taskStatus != null) {
-        String tmp = taskStatus.getData().toStringUtf8();
-        if(!tmp.isEmpty()) {
-          String jsonStr = tmp.replaceFirst("\\[", "").substring(0, (tmp.lastIndexOf(']') - 1)).trim();
+        String taskStatusData = taskStatus.getData().toStringUtf8();
+        if(!taskStatusData.isEmpty()) {
+          String jsonStr = taskStatusData.replaceFirst("\\[", "").substring(0, (taskStatusData.lastIndexOf(']') - 1)).trim();
           JSONObject jsonObject = JSONObject.fromObject(jsonStr);
           return jsonObject.getString("Name").replaceFirst("/", "").trim();
         } else {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -26,7 +26,6 @@ import hudson.slaves.ComputerLauncher;
 import hudson.slaves.EphemeralNode;
 import hudson.slaves.NodeProperty;
 import jenkins.model.Jenkins;
-import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.apache.mesos.Protos;
 import org.jenkinsci.plugins.mesos.config.slavedefinitions.MesosSlaveInfo;
@@ -43,6 +42,7 @@ public class MesosSlave extends Slave implements EphemeralNode {
   private Protos.TaskStatus taskStatus;
   private boolean pendingDelete;
   private String linkedItem;
+  private String dockerContainerID;
 
   private static final Logger LOGGER = Logger.getLogger(MesosSlave.class
       .getName());
@@ -176,17 +176,11 @@ public class MesosSlave extends Slave implements EphemeralNode {
   }
 
   public String getDockerContainerID() {
-    try {
-      if (taskStatus != null) {
-        String tmp = taskStatus.getData().toStringUtf8();
-        String jsonStr = tmp.replaceFirst("\\[","").substring(0, (tmp.lastIndexOf(']') - 1)).trim();
-        JSONObject jsonObject = JSONObject.fromObject(jsonStr);
-        return jsonObject.getString("Name").replaceFirst("/", "").trim();
-      }
-    } catch (Exception e) {
-      LOGGER.warning("Failed to get DockerContainerID from TaskStatus: " + e.getMessage());
-    }
-    return null;
+    return dockerContainerID;
+  }
+
+  public void setDockerContainerID(String dockerContainerID) {
+    this.dockerContainerID = dockerContainerID;
   }
 
   public String getMonitoringURL() {

--- a/src/main/java/org/jenkinsci/plugins/mesos/listener/MesosRunListener.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/listener/MesosRunListener.java
@@ -6,8 +6,10 @@ import hudson.model.Node;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.mesos.JenkinsScheduler;
 import org.jenkinsci.plugins.mesos.Mesos;
+import org.jenkinsci.plugins.mesos.MesosCloud;
 import org.jenkinsci.plugins.mesos.MesosSlave;
 
 import javax.annotation.CheckForNull;
@@ -86,15 +88,22 @@ public class MesosRunListener extends RunListener<Run> {
         String monitoringUrl = mesosSlave.getMonitoringURL();
         PrintStream logger = listener.getLogger();
 
-        logger.println();
         if(monitoringUrl != null) {
-          logger.println("Slave resource usage: " + monitoringUrl);
+          printMsgToLogger(logger, "Slave resource usage: " + monitoringUrl);
         } else {
-          logger.println("Slave resource usage is not available for this build.");
+          MesosCloud mesosCloud = mesosSlave.getCloud();
+          if(mesosCloud != null && !StringUtils.isBlank(mesosCloud.getGrafanaDashboardURL())){
+            printMsgToLogger(logger, "Slave resource usage is not available for this build.");
+          }
         }
-        logger.println();
       }
     }
+  }
+
+  private void printMsgToLogger(PrintStream logger, String msg) {
+    logger.println();
+    logger.println(msg);
+    logger.println();
   }
 
   private boolean skipLogfileOutputForRun(Run r) {

--- a/src/main/java/org/jenkinsci/plugins/mesos/listener/MesosRunListener.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/listener/MesosRunListener.java
@@ -89,21 +89,15 @@ public class MesosRunListener extends RunListener<Run> {
         PrintStream logger = listener.getLogger();
 
         if(monitoringUrl != null) {
-          printMsgToLogger(logger, "Slave resource usage: " + monitoringUrl);
+          logger.println("\nSlave resource usage: " + monitoringUrl + "\n");
         } else {
           MesosCloud mesosCloud = mesosSlave.getCloud();
           if(mesosCloud != null && !StringUtils.isBlank(mesosCloud.getGrafanaDashboardURL())){
-            printMsgToLogger(logger, "Slave resource usage is not available for this build.");
+            logger.println("\nSlave resource usage is not available for this build.\n");
           }
         }
       }
     }
-  }
-
-  private void printMsgToLogger(PrintStream logger, String msg) {
-    logger.println();
-    logger.println(msg);
-    logger.println();
   }
 
   private boolean skipLogfileOutputForRun(Run r) {


### PR DESCRIPTION
This Issue was caused by the Mesos Periodic Task Reconciliation.
After a new task status was requested by the scheduler, the task status
responded by the mesos master didn't contain any information in
it's "data" field.
This field, a JSON object, is used to parse out the id of the Jenkins
Slave's docker container which is later used to generate the Slave
Resource Usage link.

Also remove "Slave resource usage is not available for this build" warning
message when no grafana dashboard link is provided in the framework's config.
Slave Resource Usage will never be available if no link is set.

Issue: INFRABRBA-3897