### PR TITLE
Fix Slave Resource Usage link isn't reliable shown in build logfiles.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -887,8 +887,10 @@ public class JenkinsScheduler implements Scheduler {
 
     //setData
     Node node = Jenkins.getInstance().getNode(taskId.getValue());
+    MesosSlave mesosSlave = null;
+
     if(node != null) {
-      MesosSlave mesosSlave = (MesosSlave) node;
+      mesosSlave = (MesosSlave) node;
       mesosSlave.setTaskStatus(status);
     }
 
@@ -902,6 +904,9 @@ public class JenkinsScheduler implements Scheduler {
       break;
     case TASK_RUNNING:
       result.result.running(result.slave);
+      if(mesosSlave != null && StringUtils.isBlank(mesosSlave.getDockerContainerID())) {
+        mesosSlave.setDockerContainerID(extractContainerIdFromTaskStatus(status));
+      }
       break;
     case TASK_FINISHED:
       result.result.finished(result.slave);
@@ -1135,5 +1140,23 @@ public class JenkinsScheduler implements Scheduler {
 
   public void setJenkinsMaster(String jenkinsMaster) {
     this.jenkinsMaster = jenkinsMaster;
+  }
+
+  private String extractContainerIdFromTaskStatus(TaskStatus taskStatus) {
+    try {
+      if (taskStatus != null) {
+        String taskStatusData = taskStatus.getData().toStringUtf8();
+        if(!taskStatusData.isEmpty()) {
+          String jsonStr = taskStatusData.replaceFirst("\\[", "").substring(0, (taskStatusData.lastIndexOf(']') - 1)).trim();
+          JSONObject jsonObject = JSONObject.fromObject(jsonStr);
+          return jsonObject.getString("Name").replaceFirst("/", "").trim();
+        } else {
+          LOGGER.log(Level.WARNING, "Unable to get DockerContainerId, taskStatus has no data");
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.log(Level.WARNING, "Failed to get DockerContainerID from TaskStatus", e);
+    }
+    return null;
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -26,7 +26,6 @@ import hudson.slaves.ComputerLauncher;
 import hudson.slaves.EphemeralNode;
 import hudson.slaves.NodeProperty;
 import jenkins.model.Jenkins;
-import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.apache.mesos.Protos;
 import org.jenkinsci.plugins.mesos.config.slavedefinitions.MesosSlaveInfo;
@@ -43,6 +42,7 @@ public class MesosSlave extends Slave implements EphemeralNode {
   private Protos.TaskStatus taskStatus;
   private boolean pendingDelete;
   private String linkedItem;
+  private String dockerContainerID;
 
   private static final Logger LOGGER = Logger.getLogger(MesosSlave.class
       .getName());
@@ -176,17 +176,11 @@ public class MesosSlave extends Slave implements EphemeralNode {
   }
 
   public String getDockerContainerID() {
-    try {
-      if (taskStatus != null) {
-        String tmp = taskStatus.getData().toStringUtf8();
-        String jsonStr = tmp.replaceFirst("\\[","").substring(0, (tmp.lastIndexOf(']') - 1)).trim();
-        JSONObject jsonObject = JSONObject.fromObject(jsonStr);
-        return jsonObject.getString("Name").replaceFirst("/", "").trim();
-      }
-    } catch (Exception e) {
-      LOGGER.warning("Failed to get DockerContainerID from TaskStatus: " + e.getMessage());
-    }
-    return null;
+    return dockerContainerID;
+  }
+
+  public void setDockerContainerID(String dockerContainerID) {
+    this.dockerContainerID = dockerContainerID;
   }
 
   public String getMonitoringURL() {


### PR DESCRIPTION
This Issue was caused by the Mesos Periodic Task Reconciliation.
After a new task status was requested by the scheduler, the task status
responded by the mesos master didn't contain any information in
its "data" field.
This field, a JSON object, is used to parse out the id of the Jenkins
Agents' docker container which is later used to generate the Slave
Resource Usage link.

Also remove "Slave resource usage is not available for this build" warning
message when no grafana dashboard link is provided in the framework's config.
Slave Resource Usage will never be available if no link is set.

Issue: INFRABRBA-3897