### PR TITLE
Prevent StackOverflowException when a task refereces itself as owner

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -394,6 +394,10 @@ public class MesosCloud extends Cloud {
       return ((Item) task).getFullName();
     }
 
+    if(task.equals(task.getOwnerTask())) {
+      return task.getFullDisplayName();
+    }
+
     return getFullNameOfTask(task.getOwnerTask());
   }
 


### PR DESCRIPTION
Prevent Stack Overflow Exception when a task is referencing itself as owner.

This can happen when a PlaceholderTask, which is referencing itself as owner, is waiting for a free executor in the queue after a Jenkins restart. Normally a Placeholder Task is referencing the pipeline WorkflowJob (org.jenkinsci.plugins.workflow.job.WorkflowJob) as Owner. This occurs after a pipeline job wasn't able to finish all its steps before the restart has happened.

Issue: INFRABRBA-4011