### PR TITLE
Add tokens for container and host path, and additional commands

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/mesos/config/MesosPluginConfiguration/configureSlaveDefinitionsView.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/config/MesosPluginConfiguration/configureSlaveDefinitionsView.jelly
@@ -237,11 +237,11 @@
                                     minimum="0">
                                   <fieldset>
                                     <table width="100%">
-                                      <f:entry title="${%Container Path}">
+                                      <f:entry title="${%Container Path}" help="/plugin/mesos/help-volumeContainerPath.html" >
                                         <f:textbox field="containerPath" clazz="required" default="" value="${volume.containerPath}" />
                                       </f:entry>
 
-                                      <f:entry title="${%Host Path}">
+                                      <f:entry title="${%Host Path}" help="/plugin/mesos/help-volumeHostPath.html">
                                         <f:textbox field="hostPath" default="" value="${volume.hostPath}" />
                                       </f:entry>
 
@@ -335,7 +335,7 @@
                                   minimum="0">
                                 <fieldset>
                                   <table width="100%">
-                                    <f:entry title="${%Command}">
+                                    <f:entry title="${%Command}" help="/plugin/mesos/help-commandValue.html">
                                       <f:textbox clazz="required" field="value" default="" value="${command.value}" />
                                     </f:entry>
 

--- a/src/main/webapp/help-commandValue.html
+++ b/src/main/webapp/help-commandValue.html
@@ -1,0 +1,9 @@
+<div xmlns="http://www.w3.org/1999/html">
+    Additional commands executed before slave.jar is called<br />
+    Use:
+    <ul>
+        <li>${ITEM_FULLNAME} - replaced with linked item</li>
+        <li>${FRAMEWORK_NAME} - replaced with name of used framework</li>
+        <li>${JENKINS_MASTER} - replaced with Jenkins master defined in "Jenkins master"</li>
+    </ul>
+</div>

--- a/src/main/webapp/help-volumeContainerPath.html
+++ b/src/main/webapp/help-volumeContainerPath.html
@@ -1,0 +1,9 @@
+<div xmlns="http://www.w3.org/1999/html">
+    Path to mount in container<br />
+    Use:
+    <ul>
+        <li>${ITEM_FULLNAME} - replaced with linked item</li>
+        <li>${FRAMEWORK_NAME} - replaced with name of used framework</li>
+        <li>${JENKINS_MASTER} - replaced with Jenkins master defined in "Jenkins master"</li>
+    </ul>
+</div>

--- a/src/main/webapp/help-volumeHostPath.html
+++ b/src/main/webapp/help-volumeHostPath.html
@@ -1,0 +1,9 @@
+<div xmlns="http://www.w3.org/1999/html">
+    Path or volume name on host to mount in container<br />
+    Use:
+    <ul>
+        <li>${ITEM_FULLNAME} - replaced with linked item</li>
+        <li>${FRAMEWORK_NAME} - replaced with name of used framework</li>
+        <li>${JENKINS_MASTER} - replaced with Jenkins master defined in "Jenkins master"</li>
+    </ul>
+</div>

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -155,12 +155,7 @@ public class JenkinsSchedulerTest {
 
         assertTrue("Default shell config (true) should be configured when no container specified", commandInfo.getShell());
 
-        String jenkinsCommand2Run = jenkinsScheduler.generateJenkinsCommand2Run(
-            TEST_JENKINS_SLAVE_MEM,
-            TEST_JENKINS_SLAVE_ARG,
-            TEST_JENKINS_JNLP_ARG,
-            TEST_JENKINS_SLAVE_NAME,
-            null , null);
+        String jenkinsCommand2Run = jenkinsScheduler.generateJenkinsCommand2Run(request);
         assertEquals("jenkins command to run should be specified as value", jenkinsCommand2Run, commandInfo.getValue());
         assertEquals("mesos command should have no args specified by default", 0, commandInfo.getArgumentsCount());
     }
@@ -173,12 +168,7 @@ public class JenkinsSchedulerTest {
         Protos.CommandInfo commandInfo = commandInfoBuilder.build();
 
         assertTrue("Default shell config (true) should be configured when no container specified", commandInfo.getShell());
-        String jenkinsCommand2Run = jenkinsScheduler.generateJenkinsCommand2Run(
-            TEST_JENKINS_SLAVE_MEM,
-            TEST_JENKINS_SLAVE_ARG,
-            TEST_JENKINS_JNLP_ARG,
-            TEST_JENKINS_SLAVE_NAME,
-            null , null);
+        String jenkinsCommand2Run = jenkinsScheduler.generateJenkinsCommand2Run(request);
         assertEquals("jenkins command to run should be specified as value", jenkinsCommand2Run, commandInfo.getValue());
         assertEquals("mesos command should have no args specified by default", 0, commandInfo.getArgumentsCount());
     }
@@ -192,12 +182,7 @@ public class JenkinsSchedulerTest {
 
         assertFalse("shell should be configured as false when using a custom shell", commandInfo.getShell());
         assertEquals("Custom shell should be specified as value", "/bin/wrapdocker", commandInfo.getValue());
-        String jenkinsCommand2Run = jenkinsScheduler.generateJenkinsCommand2Run(
-                TEST_JENKINS_SLAVE_MEM,
-                TEST_JENKINS_SLAVE_ARG,
-                TEST_JENKINS_JNLP_ARG,
-                TEST_JENKINS_SLAVE_NAME,
-                null , null);
+        String jenkinsCommand2Run = jenkinsScheduler.generateJenkinsCommand2Run(request);
 
         assertEquals("args should now consist of the single original command ", 1, commandInfo.getArgumentsCount());
         assertEquals("args should now consist of the original command ", jenkinsCommand2Run, commandInfo.getArguments(0));


### PR DESCRIPTION
This commit adds the tokens:
* ${FRAMEWORK_NAME}
* ${ITEM_FULLNAME}
* ${JENKINS_MASTER}
Which can be used in host, container path and additional commands.

An example usage would be to isolate workspaces which are mounted from
a host node.

Issue: INFRABRBA-1059